### PR TITLE
[WIP] Combine energy node for summing coulomb and short-range energies.

### DIFF
--- a/alframework/ml_interfaces/hippynn_interface.py
+++ b/alframework/ml_interfaces/hippynn_interface.py
@@ -246,8 +246,8 @@ def train_HIPNN_model(model_dir,
                         raise RuntimeError('Unrecognized hipnn_order parameter')
             
                 
-                henergy = targets.HEnergyNode("node_HEnergy", network_energy,first_is_interacting)
-                sys_energy = henergy.mol_energy + coulomb_energy 
+                henergy = targets.HEnergyNode("node_shortHEnergy", network_energy,first_is_interacting)
+                sys_energy = physics.CombineEnergyNode("node_HEnergy", (henergy, coulomb_energy))
                 sys_energy.db_name = energy_key
                 
                 en_peratom = physics.PerAtom("node_EperAtom", sys_energy)

--- a/alframework/samplers/builders.py
+++ b/alframework/samplers/builders.py
@@ -27,13 +27,13 @@ from copy import deepcopy
 #    return(atom_list)
     
 @python_app(executors=['alf_sampler_executor'])
-def simple_cfg_loader_task(moleculeid,shake=0.05):
+def simple_cfg_loader_task(moleculeid,molecule_library_dir,shake=0.05):
     """
     builder_params:
     molecule_library_dir: path to molecule library
     shake: amount to displace each atom
     """
-    cfg_list = glob.glob(builder_params['molecule_library_dir']+'/*.cfg')
+    cfg_list = glob.glob(molecule_library_dir+'/*.cfg')
     cfg_choice = random.choice(cfg_list)
     atom_object = cfg.read_cfg(cfg_choice)
     atom_object.rattle(shake)


### PR DESCRIPTION
Using `CombineEnergyNode` sums up both the molecular and per-atom energies from the `henergy` and the `coulomb_energy` nodes so that it can be used with the lammps mliap interface. Needs current `development` branch of hippynn. 